### PR TITLE
Update 5.0.5 to 5.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.5" %}
+{% set version = "5.1.0" %}
 
 package:
   name: traitlets
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/traitlets/traitlets-{{ version }}.tar.gz
-  sha256: 178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396
+  sha256: bd382d7ea181fbbcce157c133db9a829ce06edffe097bcf3ab945b435452b46d
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   host:
     - python >=3.7
     - pip
+    - wheel
+    - setuptools
   run:
     - python >=3.7
     - ipython_genutils
@@ -25,6 +27,10 @@ test:
   imports:
     - traitlets
     - traitlets.config
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: http://traitlets.readthedocs.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - setuptools
   run:
     - python >=3.7
-    - ipython_genutils
 
 test:
   imports:


### PR DESCRIPTION
* [x] upstream repo https://github.com/ipython/traitlets
* [x] run tests on dependent packages - built nbclient
* [x] go through [changelog](https://github.com/ipython/traitlets/blob/main/docs/source/changelog.rst)
  * Removal of the ipython_genutils dependency, this should remove any direct and indirect reliance on nose and prepare traitlets 5.1 for Python 3.10 and above compatibility, some test suite changes also accommodate Python 3.10 changes. If you package traitlets downstream, make sure to remove this dependency.
  * Removal of ipython_genutils may have change the default encoding detected for the command line argument parsing when not utf-8. We expect this to affect a small portion of older windows version. If you encounter issue let us know.
* [x] look for any open issues for new versions
  * no open bugs on issue tracker
  * 72 issues but it's mostly dev tasks
* [x] dev_url, doc_url valid
* [x] setuptools/wheel/pip/pip check included
* [x] compare pinned versions from upstream github setup
```
meta.yaml
    - python >=3.7

setup.py
'Your pip version is out of date, please install pip >= 9.0.1. '
    python_requires = '>=3.7',
```